### PR TITLE
Fix indexing offset for backpack whilst metalpress container is current inventory context

### DIFF
--- a/src/main/java/net/silentchaos512/tutorial/block/metalpress/MetalPressContainer.java
+++ b/src/main/java/net/silentchaos512/tutorial/block/metalpress/MetalPressContainer.java
@@ -35,10 +35,10 @@ public class MetalPressContainer extends Container {
         // Player backpack
         for (int y = 0; y < 3; ++y) {
             for (int x = 0; x < 9; ++x) {
-                int index = x + y * 9;
+                int index = 9 + x + y * 9;
                 int posX = 8 + x * 18;
                 int posY = 84 + y * 18;
-                this.addSlot(new Slot(playerInventory, index + 9, posX, posY));
+                this.addSlot(new Slot(playerInventory, index, posX, posY));
             }
         }
 

--- a/src/main/java/net/silentchaos512/tutorial/block/metalpress/MetalPressContainer.java
+++ b/src/main/java/net/silentchaos512/tutorial/block/metalpress/MetalPressContainer.java
@@ -38,7 +38,7 @@ public class MetalPressContainer extends Container {
                 int index = x + y * 9;
                 int posX = 8 + x * 18;
                 int posY = 84 + y * 18;
-                this.addSlot(new Slot(playerInventory, index, posX, posY));
+                this.addSlot(new Slot(playerInventory, index + 9, posX, posY));
             }
         }
 


### PR DESCRIPTION
## Changes
* Added offset to slot index when creating backpack slots

Edit: Was made aware that @Mi1ax  had commented this fix on Ep8 so adding them as the original author of the fix.